### PR TITLE
Remove commented-out code for TCS initialization logging in qst.py

### DIFF
--- a/poulet_py/hardware/stimulator/qst.py
+++ b/poulet_py/hardware/stimulator/qst.py
@@ -516,18 +516,18 @@ class TCS:
         try:
             self.write(TCSCommand.SET_MAX_TEMPERATURE.format(int(self.maximum_temperature * 10)))
 
-            info = self.info()
-            match = search(
-                compile(r"Firmware:(.*)\nProbe ID:(.*)\nProbe TYPE:(.*)\n"),
-                info,
-            )
+            # info = self.info()
+            # match = search(
+            #     compile(r"Firmware:(.*)\nProbe ID:(.*)\nProbe TYPE:(.*)\n"),
+            #     info,
+            # )
 
-            LOGGER.info(
-                "Initialized successfully\n"
-                f"Firmware: {match.group(1).strip() if match else 'Unknown'}\n"
-                f"Probe ID: {match.group(2).strip() if match else 'Unknown'}\n"
-                f"Probe TYPE: {match.group(3).strip() if match else 'Unknown'}"
-            )
+            # LOGGER.info(
+            #     "Initialized successfully\n"
+            #     f"Firmware: {match.group(1).strip() if match else 'Unknown'}\n"
+            #     f"Probe ID: {match.group(2).strip() if match else 'Unknown'}\n"
+            #     f"Probe TYPE: {match.group(3).strip() if match else 'Unknown'}"
+            # )
         except Exception as e:
             msg = "TCS initialization failed"
             raise RuntimeError(msg) from e


### PR DESCRIPTION
I've tested poulet-py installed via `pip` on multiple Windows devices, using three different QSTboxes. Across all setups, the same error occurs when retrieving info. I haven't been able to identify the cause yet.

However, it's possible this issue is linked to other pull requests. For now, I think we should **prioritize the PR related to Write**, as resolving those might also fix the current issue.

Once the other PRs are merged or reviewed, we can revisit this one to confirm whether the problem persists or was indirectly resolved.
