### PR TITLE
Refactor command writing in TCS class to send individual characters

### DIFF
--- a/poulet_py/hardware/stimulator/qst.py
+++ b/poulet_py/hardware/stimulator/qst.py
@@ -437,9 +437,21 @@ class TCS:
             self._start_reader()
             self._serial.flush()
             LOGGER.debug(f"Sending command: {command}")
-            bytes_written = self._serial.write(command)
-            if bytes_written != len(command):
-                LOGGER.warning(f"Partial write: {bytes_written}/{len(command)} bytes")
+            command = command.decode("utf-8")
+
+            all_bytes_written = []
+            if len(command) > 1:
+                for letter in command:
+                    command = bytearray(letter, ("utf-8"))
+                    bytes_written = self._serial.write(command)
+                    if bytes_written != len(command):
+                        LOGGER.warning(f"Partial write: {bytes_written}/{len(command)} bytes")
+                    all_bytes_written.append(bytes_written)
+            else:
+                command = bytearray(command, ("utf-8"))
+                bytes_written = self._serial.write(command)
+                if bytes_written != len(command):
+                    LOGGER.warning(f"Partial write: {bytes_written}/{len(command)} bytes")
             return bytes_written
         except Exception as e:
             msg = f"Write operation failed: {e}"


### PR DESCRIPTION
The main function from TCS wasn’t working correctly. After some debugging, I found that the issue was likely caused by how the code was sending data — it was sending chunks of strings instead of single characters. For example, it tried to send the entire string representing the surface and baseline together, which the QST didn’t understand or accept.

In my proposed fix, the code now handles both single and multi-character commands. If the command string is longer than one character, it loops through and sends each character individually. This approach seems to work correctly across tests.

Additionally, I noticed that the decoding and encoding steps were inconsistent. There might have been an unnecessary decode–encode operation, depending on how the data was originally formatted. My changes ensure that data is handled as a byte array, which I think was missing in the previous implementation.

There’s probably a smarter or more elegant way to handle this, but for now, this fix seems to make the TCS function work as expected.