### PR TITLE
Filter frame keys in ThermalCamera to only include those starting with "frame"

### DIFF
--- a/poulet_py/hardware/camera/thermal_camera.py
+++ b/poulet_py/hardware/camera/thermal_camera.py
@@ -323,7 +323,7 @@ class ThermalCamera:
         """Save all frames from the current HDF5 recording as PNG images."""
 
         with h5py.File(self.output_path, "r") as f:
-            frame_keys = list(f.keys())
+            frame_keys = [key for key in f.keys() if key.startswith("frame")]
             frame_keys.sort(key=lambda x: int(x.replace("frame", "")))
 
             for frame_name in frame_keys:


### PR DESCRIPTION
This issue occurred because some files contained more than one key name and there can be multiple if the user wants.

The fix makes sure the processing is done only for the frame key, since that’s the one we use later for plotting.

This ensures that even if there are additional frame-like keys or extra metadata in the file, the code only operates on the relevant data needed for visualization.