### PR TITLE
SOHO: add PONEMAH data collector with Pydantic-validated config

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,4 @@ We welcome contributions! Follow these guidelines:
 3. Commit Messages
   * Use semantic prefixes (e.g., feat:, fix:, docs:).
 
+

--- a/poulet_py/__init__.pyi
+++ b/poulet_py/__init__.pyi
@@ -12,6 +12,7 @@ from .hardware import (
     BaseTrigger,
     GPIOTrigger,
     KeyboardTrigger,
+    Soho,
 )
 from .tools import (
     check_or_create,
@@ -49,4 +50,5 @@ __all__ = [
     "BaseTrigger",
     "GPIOTrigger",
     "KeyboardTrigger",
+    "Soho",
 ]

--- a/poulet_py/hardware/__init__.pyi
+++ b/poulet_py/hardware/__init__.pyi
@@ -2,6 +2,7 @@
 from .camera import BaslerCamera, ThermalCamera
 from .stimulator import TCS, Arduino, JulaboChiller, TCSCommand, TCSStimulus
 from .triggers import BaseTrigger, GPIOTrigger, KeyboardTrigger
+from .sensor.soho import Soho, SohoConfig
 
 __all__ = [
     "TCS",
@@ -14,4 +15,6 @@ __all__ = [
     "BaseTrigger",
     "GPIOTrigger",
     "KeyboardTrigger",
+    "Soho",
+    "SohoConfig",
 ]

--- a/poulet_py/hardware/__init__.pyi
+++ b/poulet_py/hardware/__init__.pyi
@@ -2,7 +2,7 @@
 from .camera import BaslerCamera, ThermalCamera
 from .stimulator import TCS, Arduino, JulaboChiller, TCSCommand, TCSStimulus
 from .triggers import BaseTrigger, GPIOTrigger, KeyboardTrigger
-from .sensor.soho import Soho, SohoConfig
+from .sensor.soho import Soho
 
 __all__ = [
     "TCS",
@@ -16,5 +16,4 @@ __all__ = [
     "GPIOTrigger",
     "KeyboardTrigger",
     "Soho",
-    "SohoConfig",
 ]

--- a/poulet_py/hardware/sensor/__init__.py
+++ b/poulet_py/hardware/sensor/__init__.py
@@ -1,0 +1,3 @@
+from lazy_loader import attach_stub
+
+__getattr__, __dir__, __all__ = attach_stub(__name__, __file__)

--- a/poulet_py/hardware/sensor/__init__.pyi
+++ b/poulet_py/hardware/sensor/__init__.pyi
@@ -1,0 +1,4 @@
+# ruff: noqa TID252
+from .soho import Soho, SohoConfig
+
+__all__ = ["Soho", "SohoConfig"]

--- a/poulet_py/hardware/sensor/__init__.pyi
+++ b/poulet_py/hardware/sensor/__init__.pyi
@@ -1,4 +1,4 @@
 # ruff: noqa TID252
-from .soho import Soho, SohoConfig
+from .soho import Soho
 
-__all__ = ["Soho", "SohoConfig"]
+__all__ = ["Soho"]

--- a/poulet_py/hardware/sensor/soho.py
+++ b/poulet_py/hardware/sensor/soho.py
@@ -1,0 +1,317 @@
+try:
+    from typing import Any, Dict, Optional, Tuple, Callable
+
+    import os
+    import socket
+    import struct
+    import time
+    import threading
+    import pandas as pd
+    import re
+    import msvcrt
+
+    from rich.console import Console
+    from rich.prompt import Confirm
+
+    from pydantic import BaseModel, Field
+    from poulet_py import LOGGER
+
+except ImportError as e:
+    msg = """
+Missing 'soho' module. Install options:
+- Dedicated:    pip install poulet_py[soho]
+- Module:       pip install poulet_py[hardware]
+- Full:         pip install poulet_py[all]
+"""
+    raise ImportError(msg) from e
+
+console = Console()
+
+class SohoConfig(BaseModel):
+    host: str = Field(..., min_length=1)
+    port: int = Field(..., ge=1, le=65535)
+    output_path: Optional[str] = None
+    error_log_path: Optional[str] = None
+
+class Soho:
+    """Interface for collecting data from Ponemah."""
+
+    def __init__(self, host: str | SohoConfig, port: Optional[int] = None) -> None:
+        if isinstance(host, SohoConfig):
+            self.config = host
+        else:
+            if port is None:
+                raise ValueError("port must be provided when host is a string")
+            self.config = SohoConfig(host=host, port=port)
+        self.error_log_file: Optional[str] = None
+        self.output_file: Optional[str] = None
+        self._stop = False
+        self.data: Optional[pd.DataFrame] = None
+        self.experiment_start_time: Optional[float] = None
+        self.on_data_callback: Optional[Callable[[], None]] = None
+        self._collection_thread: Optional[threading.Thread] = None
+        self._listener_thread: Optional[threading.Thread] = None
+        self._active = True
+
+    def set_error_log_path(self, path: str, file_name: str) -> None:
+        """Set the file used for error logging."""
+        self.error_log_file = os.path.join(path, file_name)
+
+    def set_output_file(self, path: str, extra_name: str, base_file_name: str) -> None:
+        """Configure the output CSV file."""
+        name = f"{extra_name}_{base_file_name}"
+        self.output_file = os.path.join(path, name)
+
+    def set_experiment_start_time(self, start_time: float) -> None:
+        """Set the shared experiment start time."""
+        self.experiment_start_time = start_time
+
+    def set_on_data_callback(self, callback: Callable[[], None]) -> None:
+        """Set a callback to be called when data is received."""
+        self.on_data_callback = callback
+
+    def collect(self) -> pd.DataFrame:
+        """Collect data from the Ponemah server."""
+        metadata: Dict[str, Dict[str, Any]] = {}
+        rows: Dict[Tuple[str, str], Dict[Tuple[str, str], str]] = {}
+        previous_data = self.data
+
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.connect((self.config.host, self.config.port))
+                sock.settimeout(1.0)
+                while not self._stop:
+                    try:
+                        raw_len = self._read_exact(sock, 2)
+                        length = struct.unpack(">H", raw_len)[0]
+                        payload = self._read_exact(sock, length)
+                        text = payload.decode("ascii", errors="ignore").strip()
+                        fields = text.split(";")
+                        msg_type = fields[0]
+
+                        if msg_type == "1":
+                            inst_id = fields[1]
+                            metadata[inst_id] = {
+                                "subject_id": fields[3],
+                                "channel_number": fields[4],
+                                "channel_label": fields[5],
+                                "channel_analysis": fields[6],
+                                "param_names": fields[7].split(","),
+                            }
+                        elif msg_type == "2":
+                            ref_id = fields[2]
+                            values = fields[3].split(",")
+                            meta = metadata.get(ref_id)
+                            if meta:
+                                param_names = meta["param_names"]
+                                data = dict(zip(param_names, values))
+
+                                elapsed = data.pop("ElapsedTime", "")
+                                real = data.pop("RealTime", "")
+                                event = data.pop("Event", "")
+                                key = (elapsed, real)
+
+                                row = rows.setdefault(
+                                    key,
+                                    {
+                                        ("meta", "ElapsedTime"): elapsed,
+                                        ("meta", "RealTime"): real,
+                                        ("meta", "Event"): event,
+                                    },
+                                )
+                                if self.experiment_start_time is not None:
+                                    timestamp = time.time() - self.experiment_start_time
+                                    row[("meta", "experiment_timestamp")] = f"{timestamp:.6f}"
+                                row[("meta", "subject_id")] = meta["subject_id"]
+                                channel = meta["channel_label"]
+                                for name, value in data.items():
+                                    row[(channel, name)] = value
+                                
+                                if self.on_data_callback is not None:
+                                    try:
+                                        self.on_data_callback()
+                                    except Exception as e:
+                                        Soho.log_error(f"Error in data callback: {e}", self.error_log_file)
+                    except socket.timeout:
+                        continue
+                    except (ConnectionError, OSError) as err:
+                        Soho.log_error(str(err), self.error_log_file)
+                        break
+        except (ConnectionError, OSError) as err:
+            Soho.log_error(str(err), self.error_log_file)
+
+        ordered_rows = list(rows.values())
+        df = pd.DataFrame(ordered_rows)
+        if not df.empty and len(df.columns) > 0:
+            df.columns = pd.MultiIndex.from_tuples(df.columns)
+        
+        if previous_data is not None and not previous_data.empty:
+            if not df.empty:
+                self.data = pd.concat(
+                    [previous_data, df], ignore_index=True
+                )
+            else:
+                self.data = previous_data
+        else:
+            self.data = df
+        
+        return self.data
+
+    def save(self) -> None:
+        """Save collected data to the configured CSV file."""
+        if self.output_file is None or self.data is None:
+            Soho.log_error("Output file or data not set.", self.error_log_file)
+            return
+        try:
+            self.data.to_csv(self.output_file, index=False)
+        except OSError as err:
+            Soho.log_error(str(err), self.error_log_file)
+
+    def start(self) -> None:
+        """Start data collection and keyboard listener threads."""
+        self._active = True
+        self._stop = False
+
+        console.input(
+            "[bold yellow]\nWARNING: Ensure that the continuous sampling is "
+            "activated. Press Enter when you're ready to start recording."
+        )
+
+        console.rule("[bold cyan]🟢 RECORDING WITH PONEMAH[/bold cyan]", style="bold cyan")
+        console.print("Press 'e' to end recording, 't' to test connection.")
+
+        self._collection_thread = threading.Thread(target=self.collect)
+        self._collection_thread.start()
+        
+        self._listener_thread = threading.Thread(
+            target=self._keyboard_listener
+        )
+        self._listener_thread.start()
+        
+        console.print("[bold green]Soho recording started.[/bold green]")
+
+    def stop(self) -> None:
+        """Signal the collector to stop."""
+        self._stop = True
+        self._active = False
+
+    def wait_for_completion(self) -> None:
+        """Wait for both threads to complete."""
+        if self._listener_thread:
+            self._listener_thread.join()
+        if self._collection_thread:
+            self._collection_thread.join()
+
+    def pause_and_test_connection(self) -> None:
+        """Pause recording, test connection, and optionally resume."""
+        console.print("[bold yellow]Pausing recording...[/bold yellow]")
+        self._stop = True
+        
+        if self._collection_thread:
+            self._collection_thread.join()
+        
+        console.print("[bold cyan]🔌 CONNECTION TEST[/bold cyan]")
+        console.input(
+            "Go to Ponemah 'Experiment Setup' and click 'Test' remote "
+            "connection. Press Enter when ready to test."
+        )
+        
+        test_ponemah_connection(self.config.host, self.config.port)
+        
+        console.input(
+            "Close the remote connection test window by pressing 'OK'. "
+            "Press Enter when done."
+        )
+        
+        confirm_resume = Confirm.ask("[yellow]Resume recording? (y/n)[/yellow]", default=True)
+        
+        if confirm_resume:
+            console.input(
+                "[bold yellow]\nWARNING: Ensure that the continuous sampling is "
+                "activated. Press Enter when you're ready to start recording."
+            )
+            self._stop = False
+            self._collection_thread = threading.Thread(target=self.collect)
+            self._collection_thread.start()
+            console.print("[bold green]Recording resumed.[/bold green]")
+        else:
+            console.print("[bold red]Recording not resumed.[/bold red]")
+            self._active = False
+
+    def _keyboard_listener(self) -> None:
+        """Monitor keyboard input for stopping or testing connection."""
+        if msvcrt is None:
+            input()
+            console.print(
+                "Recording finished, stopping Soho, "
+                "waiting for the last reading..."
+            )
+            self.stop()
+            return
+        
+        while self._active:
+            if msvcrt.kbhit():
+                key = msvcrt.getwch()
+                
+                if key.lower() == "e":
+                    confirm = Confirm.ask(
+                        "Are you sure you want to stop recording? (y/n): "
+                    , default=True)
+                    
+                    if confirm:
+                        console.print("[bold green]Stopping recording...[/bold green]")
+                        self.stop()
+                        break
+                
+                elif key.lower() == "t":
+                    confirm = Confirm.ask(
+                        "Pause recording to test connection? (y/n): "
+                    , default=True)
+                    
+                    if confirm:
+                        self.pause_and_test_connection()
+            
+            time.sleep(0.1)
+
+    @staticmethod
+    def log_error(error_message: str, error_log_file: Optional[str]) -> None:
+        if error_log_file:
+            try:
+                with open(error_log_file, "a", encoding="utf-8") as f:
+                    f.write(error_message + "\n")
+            except Exception:
+                LOGGER.error(error_message)
+                return
+        LOGGER.error(error_message)
+
+    @staticmethod
+    def _read_exact(sock: socket.socket, n: int) -> bytes:
+        """Read exactly n bytes from a socket."""
+        buf = bytearray()
+        while len(buf) < n:
+            chunk = sock.recv(n - len(buf))
+            if not chunk:
+                raise ConnectionError("Socket closed while reading")
+            buf.extend(chunk)
+        return bytes(buf)
+
+
+def test_ponemah_connection(HOST: str, PORT: int) -> None:
+    """Test connection to Ponemah server."""
+    console.print("Testing remote connection with PONEMAH")
+    while True:
+        try:
+            with socket.create_connection((HOST, PORT), timeout=1) as sock:
+                sock.settimeout(1)
+                raw = sock.recv(1024).decode("ascii", errors="ignore")
+                clean = re.sub(r"[^ -~]", "", raw).strip()
+                if ";;0" in clean or "0;;" in clean:
+                    console.print("[bold green]Response successful[/bold green]")
+                    return True
+                console.print(f"[red]Unexpected response:[/red] {clean!r}")
+        except OSError:
+            console.print(
+                "[red]Connection refused, start test in setup remote "
+                "connection test[/red]"
+            )
+        time.sleep(1)

--- a/poulet_py/hardware/sensor/soho.py
+++ b/poulet_py/hardware/sensor/soho.py
@@ -1,16 +1,17 @@
 try:
-    import msvcrt
-    import os
-    import re
-    import socket
-    import struct
-    import threading
-    import time
     from collections.abc import Callable
-    from typing import Any, Dict, Optional, Tuple
+    from os.path import join
+    from re import sub
+    from socket import AF_INET, SOCK_STREAM, create_connection
+    from socket import socket as Socket
+    from struct import unpack
+    from threading import Thread
+    from time import sleep, time
+    from typing import Any
 
-    import pandas as pd
+    from pandas import DataFrame, MultiIndex, concat
     from pydantic import BaseModel, Field, PrivateAttr
+    from pynput.keyboard import Key, Listener
     from rich.console import Console
     from rich.prompt import Confirm
 
@@ -38,8 +39,8 @@ class Soho(BaseModel):
 
     _stop: bool = PrivateAttr(False)
     _active: bool = PrivateAttr(True)
-    _collection_thread: threading.Thread | None = PrivateAttr(None)
-    _listener_thread: threading.Thread | None = PrivateAttr(None)
+    _collection_thread: Thread | None = PrivateAttr(None)
+    _keyboard_listener_instance: Listener | None = PrivateAttr(None)
 
     def __init__(
         self,
@@ -54,18 +55,18 @@ class Soho(BaseModel):
         )
         self.error_log_file: str | None = None
         self.output_file: str | None = None
-        self.data: pd.DataFrame | None = None
+        self.data: DataFrame | None = None
         self.experiment_start_time: float | None = None
         self.on_data_callback: Callable[[], None] | None = None
 
     def set_error_log_path(self, path: str, file_name: str) -> None:
         """Set the file used for error logging."""
-        self.error_log_file = os.path.join(path, file_name)
+        self.error_log_file = join(path, file_name)
 
     def set_output_file(self, path: str, extra_name: str, base_file_name: str) -> None:
         """Configure the output CSV file."""
         name = f"{extra_name}_{base_file_name}"
-        self.output_file = os.path.join(path, name)
+        self.output_file = join(path, name)
 
     def set_experiment_start_time(self, start_time: float) -> None:
         """Set the shared experiment start time."""
@@ -75,20 +76,20 @@ class Soho(BaseModel):
         """Set a callback to be called when data is received."""
         self.on_data_callback = callback
 
-    def collect(self) -> pd.DataFrame:
+    def collect(self) -> DataFrame:
         """Collect data from the Ponemah server."""
         metadata: dict[str, dict[str, Any]] = {}
         rows: dict[tuple[str, str], dict[tuple[str, str], str]] = {}
         previous_data = self.data
 
         try:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            with Socket(AF_INET, SOCK_STREAM) as sock:
                 sock.connect((self.host, self.port))
                 sock.settimeout(1.0)
                 while not self._stop:
                     try:
                         raw_len = self._read_exact(sock, 2)
-                        length = struct.unpack(">H", raw_len)[0]
+                        length = unpack(">H", raw_len)[0]
                         payload = self._read_exact(sock, length)
                         text = payload.decode("ascii", errors="ignore").strip()
                         fields = text.split(";")
@@ -125,7 +126,7 @@ class Soho(BaseModel):
                                     },
                                 )
                                 if self.experiment_start_time is not None:
-                                    timestamp = time.time() - self.experiment_start_time
+                                    timestamp = time() - self.experiment_start_time
                                     row[("meta", "experiment_timestamp")] = f"{timestamp:.6f}"
                                 row[("meta", "subject_id")] = meta["subject_id"]
                                 channel = meta["channel_label"]
@@ -148,13 +149,13 @@ class Soho(BaseModel):
             Soho.log_error(str(err), self.error_log_file)
 
         ordered_rows = list(rows.values())
-        df = pd.DataFrame(ordered_rows)
+        df = DataFrame(ordered_rows)
         if not df.empty and len(df.columns) > 0:
-            df.columns = pd.MultiIndex.from_tuples(df.columns)
+            df.columns = MultiIndex.from_tuples(df.columns)
 
         if previous_data is not None and not previous_data.empty:
             if not df.empty:
-                self.data = pd.concat([previous_data, df], ignore_index=True)
+                self.data = concat([previous_data, df], ignore_index=True)
             else:
                 self.data = previous_data
         else:
@@ -185,11 +186,10 @@ class Soho(BaseModel):
         console.rule("[bold cyan]🟢 RECORDING WITH PONEMAH[/bold cyan]", style="bold cyan")
         console.print("Press 'e' to end recording, 't' to test connection.")
 
-        self._collection_thread = threading.Thread(target=self.collect)
+        self._collection_thread = Thread(target=self.collect)
         self._collection_thread.start()
 
-        self._listener_thread = threading.Thread(target=self._keyboard_listener)
-        self._listener_thread.start()
+        self._start_keyboard_listener()
 
         console.print("[bold green]Soho recording started.[/bold green]")
 
@@ -197,11 +197,11 @@ class Soho(BaseModel):
         """Signal the collector to stop."""
         self._stop = True
         self._active = False
+        self._stop_keyboard_listener()
 
     def wait_for_completion(self) -> None:
         """Wait for both threads to complete."""
-        if self._listener_thread:
-            self._listener_thread.join()
+        self._stop_keyboard_listener()
         if self._collection_thread:
             self._collection_thread.join()
 
@@ -233,47 +233,59 @@ class Soho(BaseModel):
                 "activated. Press Enter when you're ready to start recording."
             )
             self._stop = False
-            self._collection_thread = threading.Thread(target=self.collect)
+            self._collection_thread = Thread(target=self.collect)
             self._collection_thread.start()
             console.print("[bold green]Recording resumed.[/bold green]")
         else:
             console.print("[bold red]Recording not resumed.[/bold red]")
             self._active = False
 
-    def _keyboard_listener(self) -> None:
-        """Monitor keyboard input for stopping or testing connection."""
-        if msvcrt is None:
-            input()
-            console.print("Recording finished, stopping Soho, waiting for the last reading...")
-            self.stop()
-            return
+    def _start_keyboard_listener(self) -> None:
+        """Start the pynput keyboard listener."""
+        self._keyboard_listener_instance = Listener(on_press=self._on_key_press)
+        self._keyboard_listener_instance.start()
 
-        while self._active:
-            if msvcrt.kbhit():
-                key = msvcrt.getwch()
+    def _stop_keyboard_listener(self) -> None:
+        """Stop the pynput keyboard listener."""
+        if self._keyboard_listener_instance is not None:
+            self._keyboard_listener_instance.stop()
+            self._keyboard_listener_instance = None
 
-                if key.lower() == "e":
-                    confirm = Confirm.ask(
-                        "Are you sure you want to stop recording? (y/n): ", default=True
-                    )
+    def _on_key_press(self, key: Key) -> bool | None:
+        """Handle key press events from pynput."""
+        if not self._active:
+            return False
 
-                    if confirm:
-                        console.print("[bold green]Stopping recording...[/bold green]")
-                        self.stop()
-                        break
+        try:
+            key_char = key.char if hasattr(key, "char") else None
+        except AttributeError:
+            return None
 
-                elif key.lower() == "t":
-                    confirm = Confirm.ask(
-                        "Pause recording to test connection? (y/n): ", default=True
-                    )
+        if key_char is None:
+            return None
 
-                    if confirm:
-                        self.pause_and_test_connection()
+        if key_char.lower() == "e":
+            confirm = Confirm.ask(
+                "Are you sure you want to stop recording? (y/n): ", default=True
+            )
 
-            time.sleep(0.1)
+            if confirm:
+                console.print("[bold green]Stopping recording...[/bold green]")
+                self.stop()
+                return False
+
+        elif key_char.lower() == "t":
+            confirm = Confirm.ask(
+                "Pause recording to test connection? (y/n): ", default=True
+            )
+
+            if confirm:
+                self.pause_and_test_connection()
+
+        return None
 
     @staticmethod
-    def _read_exact(sock: socket.socket, n: int) -> bytes:
+    def _read_exact(sock: Socket, n: int) -> bytes:
         """Read exactly n bytes from a socket."""
         buf = bytearray()
         while len(buf) < n:
@@ -283,16 +295,24 @@ class Soho(BaseModel):
             buf.extend(chunk)
         return bytes(buf)
 
+    @staticmethod
+    def log_error(message: str, log_file: str | None = None) -> None:
+        """Log an error message to LOGGER and optionally to a file."""
+        LOGGER.error(message)
+        if log_file is not None:
+            with open(log_file, "a", encoding="utf-8") as f:
+                f.write(f"{message}\n")
 
-def test_ponemah_connection(HOST: str, PORT: int) -> None:
+
+def test_ponemah_connection(host: str, port: int) -> bool:
     """Test connection to Ponemah server."""
     console.print("Testing remote connection with PONEMAH")
     while True:
         try:
-            with socket.create_connection((HOST, PORT), timeout=1) as sock:
+            with create_connection((host, port), timeout=1) as sock:
                 sock.settimeout(1)
                 raw = sock.recv(1024).decode("ascii", errors="ignore")
-                clean = re.sub(r"[^ -~]", "", raw).strip()
+                clean = sub(r"[^ -~]", "", raw).strip()
                 if ";;0" in clean or "0;;" in clean:
                     console.print("[bold green]Response successful[/bold green]")
                     return True
@@ -301,4 +321,4 @@ def test_ponemah_connection(HOST: str, PORT: int) -> None:
             console.print(
                 "[red]Connection refused, start test in setup remote connection test[/red]"
             )
-        time.sleep(1)
+        sleep(1)

--- a/poulet_py/hardware/sensor/soho.py
+++ b/poulet_py/hardware/sensor/soho.py
@@ -1,3 +1,19 @@
+"""
+Soho (Ponemah) data collection interface module.
+
+This module provides a Python interface for collecting physiological data
+from DSI Ponemah software via TCP socket connection. It supports real-time
+data streaming, keyboard-controlled recording sessions, and CSV export.
+
+Examples
+--------
+>>> soho = Soho(host="192.168.1.100", port=9000)
+>>> soho.set_output_file("/data", "experiment", "subject01.csv")
+>>> soho.start()
+>>> soho.wait_for_completion()
+>>> soho.save()
+"""
+
 try:
     from collections.abc import Callable
     from os.path import join
@@ -30,7 +46,80 @@ console = Console()
 
 
 class Soho(BaseModel):
-    """Interface for collecting data from Ponemah."""
+    """
+    Interface for collecting physiological data from DSI Ponemah software.
+
+    This class establishes a TCP socket connection to the Ponemah server and
+    collects streaming data in real-time. It provides keyboard controls for
+    managing recording sessions and supports CSV export of collected data.
+
+    Parameters
+    ----------
+    host : str
+        IP address or hostname of the Ponemah server.
+    port : int
+        TCP port number for the Ponemah connection (1-65535).
+    output_path : str, optional
+        Default output directory path for data files.
+    error_log_path : str, optional
+        Default directory path for error log files.
+
+    Attributes
+    ----------
+    host : str
+        IP address or hostname of the Ponemah server.
+    port : int
+        TCP port number for the Ponemah connection.
+    output_path : str or None
+        Default output directory path for data files.
+    error_log_path : str or None
+        Default directory path for error log files.
+    error_log_file : str or None
+        Full path to the error log file.
+    output_file : str or None
+        Full path to the output CSV file.
+    data : DataFrame or None
+        Collected data as a pandas DataFrame with MultiIndex columns.
+    experiment_start_time : float or None
+        Unix timestamp marking the start of the experiment.
+    on_data_callback : Callable or None
+        Optional callback function invoked when data is received.
+
+    Methods
+    -------
+    set_error_log_path(path, file_name)
+        Configure the error log file path.
+    set_output_file(path, extra_name, base_file_name)
+        Configure the output CSV file path.
+    set_experiment_start_time(start_time)
+        Set the experiment start timestamp.
+    set_on_data_callback(callback)
+        Register a callback for data reception events.
+    collect()
+        Collect data from the Ponemah server.
+    save()
+        Save collected data to CSV file.
+    start()
+        Begin data collection with keyboard controls.
+    stop()
+        Stop data collection.
+    wait_for_completion()
+        Block until collection threads complete.
+    pause_and_test_connection()
+        Pause recording and test the server connection.
+    log_error(message, log_file)
+        Log an error message.
+
+    Examples
+    --------
+    >>> soho = Soho(host="192.168.1.100", port=9000)
+    >>> soho.set_output_file("/data", "experiment", "subject01.csv")
+    >>> soho.set_error_log_path("/logs", "errors.log")
+    >>> soho.start()
+    >>> soho.wait_for_completion()
+    >>> soho.save()
+    >>> print(soho.data.head())
+    """
 
     host: str = Field(..., min_length=1)
     port: int = Field(..., ge=1, le=65535)
@@ -50,6 +139,22 @@ class Soho(BaseModel):
         error_log_path: str | None = None,
         **kwargs,
     ) -> None:
+        """
+        Initialize a Soho data collector instance.
+
+        Parameters
+        ----------
+        host : str
+            IP address or hostname of the Ponemah server.
+        port : int
+            TCP port number for the Ponemah connection (1-65535).
+        output_path : str, optional
+            Default output directory path for data files.
+        error_log_path : str, optional
+            Default directory path for error log files.
+        **kwargs
+            Additional keyword arguments passed to BaseModel.
+        """
         super().__init__(
             host=host, port=port, output_path=output_path, error_log_path=error_log_path, **kwargs
         )
@@ -60,24 +165,87 @@ class Soho(BaseModel):
         self.on_data_callback: Callable[[], None] | None = None
 
     def set_error_log_path(self, path: str, file_name: str) -> None:
-        """Set the file used for error logging."""
+        """
+        Configure the file path for error logging.
+
+        Parameters
+        ----------
+        path : str
+            Directory path where the error log file will be stored.
+        file_name : str
+            Name of the error log file.
+        """
         self.error_log_file = join(path, file_name)
 
     def set_output_file(self, path: str, extra_name: str, base_file_name: str) -> None:
-        """Configure the output CSV file."""
+        """
+        Configure the output CSV file path.
+
+        The final filename is constructed as "{extra_name}_{base_file_name}".
+
+        Parameters
+        ----------
+        path : str
+            Directory path where the output file will be stored.
+        extra_name : str
+            Prefix to prepend to the base filename.
+        base_file_name : str
+            Base name of the output file (typically includes .csv extension).
+        """
         name = f"{extra_name}_{base_file_name}"
         self.output_file = join(path, name)
 
     def set_experiment_start_time(self, start_time: float) -> None:
-        """Set the shared experiment start time."""
+        """
+        Set the experiment start timestamp for relative timing.
+
+        When set, collected data will include an experiment_timestamp column
+        calculated as the offset from this start time.
+
+        Parameters
+        ----------
+        start_time : float
+            Unix timestamp (seconds since epoch) marking experiment start.
+        """
         self.experiment_start_time = start_time
 
     def set_on_data_callback(self, callback: Callable[[], None]) -> None:
-        """Set a callback to be called when data is received."""
+        """
+        Register a callback function for data reception events.
+
+        The callback is invoked each time a data packet is received from
+        the Ponemah server. Exceptions in the callback are logged but do
+        not interrupt data collection.
+
+        Parameters
+        ----------
+        callback : Callable[[], None]
+            A function with no arguments to be called on data reception.
+        """
         self.on_data_callback = callback
 
     def collect(self) -> DataFrame:
-        """Collect data from the Ponemah server."""
+        """
+        Collect data from the Ponemah server via TCP socket.
+
+        Establishes a connection to the configured host and port, then
+        continuously reads and parses data packets until stopped. Data is
+        accumulated and merged with any previously collected data.
+
+        Returns
+        -------
+        DataFrame
+            Collected data with MultiIndex columns organized by channel
+            and parameter name. Includes metadata columns for timing and
+            subject identification.
+
+        Raises
+        ------
+        ConnectionError
+            If the socket connection fails or is unexpectedly closed.
+        OSError
+            If a network-related error occurs during data collection.
+        """
         metadata: dict[str, dict[str, Any]] = {}
         rows: dict[tuple[str, str], dict[tuple[str, str], str]] = {}
         previous_data = self.data
@@ -164,7 +332,18 @@ class Soho(BaseModel):
         return self.data
 
     def save(self) -> None:
-        """Save collected data to the configured CSV file."""
+        """
+        Save collected data to the configured CSV file.
+
+        Writes the accumulated DataFrame to the output file path configured
+        via set_output_file(). If no output file or data is available,
+        an error is logged and the method returns without action.
+
+        Raises
+        ------
+        OSError
+            If the file cannot be written due to permissions or disk errors.
+        """
         if self.output_file is None or self.data is None:
             Soho.log_error("Output file or data not set.", self.error_log_file)
             return
@@ -174,7 +353,13 @@ class Soho(BaseModel):
             Soho.log_error(str(err), self.error_log_file)
 
     def start(self) -> None:
-        """Start data collection and keyboard listener threads."""
+        """
+        Start data collection with interactive keyboard controls.
+
+        Launches background threads for data collection and keyboard
+        monitoring. Prompts the user to confirm readiness before starting.
+        During recording, press 'e' to end or 't' to test the connection.
+        """
         self._active = True
         self._stop = False
 
@@ -194,19 +379,37 @@ class Soho(BaseModel):
         console.print("[bold green]Soho recording started.[/bold green]")
 
     def stop(self) -> None:
-        """Signal the collector to stop."""
+        """
+        Signal the data collector to stop recording.
+
+        Sets internal flags to terminate the collection loop and stops
+        the keyboard listener. The collection thread will complete its
+        current operation before fully stopping.
+        """
         self._stop = True
         self._active = False
         self._stop_keyboard_listener()
 
     def wait_for_completion(self) -> None:
-        """Wait for both threads to complete."""
+        """
+        Block until all collection threads have completed.
+
+        Stops the keyboard listener and waits for the data collection
+        thread to finish. Call this method after start() to ensure all
+        data has been collected before saving or processing.
+        """
         self._stop_keyboard_listener()
         if self._collection_thread:
             self._collection_thread.join()
 
     def pause_and_test_connection(self) -> None:
-        """Pause recording, test connection, and optionally resume."""
+        """
+        Pause recording to test the Ponemah server connection.
+
+        Temporarily stops data collection, guides the user through testing
+        the remote connection in Ponemah, and offers the option to resume
+        recording afterward. Previously collected data is preserved.
+        """
         console.print("[bold yellow]Pausing recording...[/bold yellow]")
         self._stop = True
 
@@ -282,7 +485,26 @@ class Soho(BaseModel):
 
     @staticmethod
     def _read_exact(sock: Socket, n: int) -> bytes:
-        """Read exactly n bytes from a socket."""
+        """
+        Read exactly n bytes from a socket.
+
+        Parameters
+        ----------
+        sock : Socket
+            Connected socket to read from.
+        n : int
+            Exact number of bytes to read.
+
+        Returns
+        -------
+        bytes
+            The requested bytes read from the socket.
+
+        Raises
+        ------
+        ConnectionError
+            If the socket is closed before all bytes are read.
+        """
         buf = bytearray()
         while len(buf) < n:
             chunk = sock.recv(n - len(buf))
@@ -293,7 +515,17 @@ class Soho(BaseModel):
 
     @staticmethod
     def log_error(message: str, log_file: str | None = None) -> None:
-        """Log an error message to LOGGER and optionally to a file."""
+        """
+        Log an error message to the application logger and optionally to a file.
+
+        Parameters
+        ----------
+        message : str
+            The error message to log.
+        log_file : str, optional
+            Path to a file where the message should also be appended.
+            If None, the message is only logged to LOGGER.
+        """
         LOGGER.error(message)
         if log_file is not None:
             with open(log_file, "a", encoding="utf-8") as f:
@@ -301,7 +533,25 @@ class Soho(BaseModel):
 
 
 def test_ponemah_connection(host: str, port: int) -> bool:
-    """Test connection to Ponemah server."""
+    """
+    Test the TCP connection to a Ponemah server.
+
+    Attempts to connect to the specified host and port, waiting for a valid
+    response from the Ponemah remote connection test. Retries indefinitely
+    until a successful connection is established.
+
+    Parameters
+    ----------
+    host : str
+        IP address or hostname of the Ponemah server.
+    port : int
+        TCP port number for the Ponemah connection.
+
+    Returns
+    -------
+    bool
+        True when a successful connection response is received.
+    """
     console.print("Testing remote connection with PONEMAH")
     while True:
         try:

--- a/poulet_py/hardware/sensor/soho.py
+++ b/poulet_py/hardware/sensor/soho.py
@@ -341,9 +341,7 @@ class Soho(BaseModel):
                                         )
                                 self._packet_count += 1
                                 if self._packet_count % 100 == 0:
-                                    self._update_data_from_rows(
-                                        rows, metadata, previous_data
-                                    )
+                                    self._update_data_from_rows(rows, metadata, previous_data)
                     except TimeoutError:
                         continue
                     except (ConnectionError, OSError) as err:

--- a/poulet_py/hardware/sensor/soho.py
+++ b/poulet_py/hardware/sensor/soho.py
@@ -16,7 +16,8 @@ Examples
 
 try:
     from collections.abc import Callable
-    from os.path import join
+    from os.path import basename, exists, join
+    from subprocess import Popen
     from re import sub
     from socket import AF_INET, SOCK_STREAM, create_connection
     from socket import socket as Socket
@@ -43,6 +44,10 @@ Missing 'soho' module. Install options:
     raise ImportError(msg) from e
 
 console = Console()
+
+HOST = "localhost"
+PORT = 6732
+PONEMAH_EXECUTABLE = r"C:\\Ponemah\\PPP3.exe"
 
 
 class Soho(BaseModel):
@@ -121,8 +126,8 @@ class Soho(BaseModel):
     >>> print(soho.data.head())
     """
 
-    host: str = Field(..., min_length=1)
-    port: int = Field(..., ge=1, le=65535)
+    host: str = Field(HOST, min_length=1)
+    port: int = Field(PORT, ge=1, le=65535)
     output_path: str | None = None
     error_log_path: str | None = None
 
@@ -133,8 +138,8 @@ class Soho(BaseModel):
 
     def __init__(
         self,
-        host: str,
-        port: int,
+        host: str = HOST,
+        port: int = PORT,
         output_path: str | None = None,
         error_log_path: str | None = None,
         **kwargs,
@@ -568,3 +573,70 @@ def test_ponemah_connection(host: str, port: int) -> bool:
                 "[red]Connection refused, start test in setup remote connection test[/red]"
             )
         sleep(1)
+
+
+def open_ponemah(
+    executable: str = PONEMAH_EXECUTABLE,
+    wait_seconds: float = 4.0,
+    run_as_admin: bool = True,
+) -> bool:
+    """
+    Launch Ponemah executable if available.
+
+    Ponemah is the DSI telemetry software that Soho connects to for data
+    collection. This helper launches it, typically with elevated privileges.
+
+    Parameters
+    ----------
+    executable : str, optional
+        Full path to the Ponemah executable.
+    wait_seconds : float, optional
+        Time to wait after launching, allowing the UI to open.
+    run_as_admin : bool, optional
+        If True, launch with RunAs (admin). Default True.
+
+    Returns
+    -------
+    bool
+        True if Ponemah is already running or launch succeeds, otherwise False.
+    """
+    try:
+        import psutil
+    except ImportError:
+        psutil = None
+
+    name = basename(executable)
+    if psutil is not None:
+        for proc in psutil.process_iter(["name"]):
+            if proc.info["name"] == name:
+                console.print("[bold green]Ponemah already running.[/bold green]")
+                return True
+
+    if not exists(executable):
+        msg = f"Ponemah executable not found: {executable}"
+        LOGGER.error(msg)
+        console.print(f"[red]{msg}[/red]")
+        return False
+
+    try:
+        if run_as_admin:
+            import subprocess
+            subprocess.run(
+                [
+                    "powershell",
+                    "-Command",
+                    f'Start-Process "{executable}" -Verb RunAs',
+                ],
+                check=True,
+            )
+        else:
+            Popen(executable)
+        LOGGER.info("Ponemah launched successfully")
+        console.print("[bold green]Ponemah launched.[/bold green]")
+        sleep(wait_seconds)
+        return True
+    except OSError as err:
+        msg = f"Failed to open Ponemah: {err}"
+        LOGGER.error(msg)
+        console.print(f"[red]{msg}[/red]")
+        return False

--- a/poulet_py/hardware/sensor/soho.py
+++ b/poulet_py/hardware/sensor/soho.py
@@ -273,16 +273,6 @@ class Soho:
             
             time.sleep(0.1)
 
-    @staticmethod
-    def log_error(error_message: str, error_log_file: Optional[str]) -> None:
-        if error_log_file:
-            try:
-                with open(error_log_file, "a", encoding="utf-8") as f:
-                    f.write(error_message + "\n")
-            except Exception:
-                LOGGER.error(error_message)
-                return
-        LOGGER.error(error_message)
 
     @staticmethod
     def _read_exact(sock: socket.socket, n: int) -> bytes:

--- a/poulet_py/hardware/sensor/soho.py
+++ b/poulet_py/hardware/sensor/soho.py
@@ -27,7 +27,7 @@ try:
     from typing import Any
 
     from pandas import DataFrame, MultiIndex, concat
-    from pydantic import BaseModel, Field, PrivateAttr
+    from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
     from pynput.keyboard import Key, Listener
     from rich.console import Console
     from rich.prompt import Confirm
@@ -126,10 +126,17 @@ class Soho(BaseModel):
     >>> print(soho.data.head())
     """
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     host: str = Field(HOST, min_length=1)
     port: int = Field(PORT, ge=1, le=65535)
     output_path: str | None = None
     error_log_path: str | None = None
+    error_log_file: str | None = None
+    output_file: str | None = None
+    data: DataFrame | None = None
+    experiment_start_time: float | None = None
+    on_data_callback: Callable[[], None] | None = None
 
     _stop: bool = PrivateAttr(False)
     _active: bool = PrivateAttr(True)
@@ -163,11 +170,6 @@ class Soho(BaseModel):
         super().__init__(
             host=host, port=port, output_path=output_path, error_log_path=error_log_path, **kwargs
         )
-        self.error_log_file: str | None = None
-        self.output_file: str | None = None
-        self.data: DataFrame | None = None
-        self.experiment_start_time: float | None = None
-        self.on_data_callback: Callable[[], None] | None = None
 
     def set_error_log_path(self, path: str, file_name: str) -> None:
         """

--- a/poulet_py/hardware/sensor/soho.py
+++ b/poulet_py/hardware/sensor/soho.py
@@ -13,7 +13,7 @@ try:
     from rich.console import Console
     from rich.prompt import Confirm
 
-    from pydantic import BaseModel, Field
+    from pydantic import BaseModel, Field, PrivateAttr
     from poulet_py import LOGGER
 
 except ImportError as e:
@@ -27,31 +27,26 @@ Missing 'soho' module. Install options:
 
 console = Console()
 
-class SohoConfig(BaseModel):
+class Soho(BaseModel):
+    """Interface for collecting data from Ponemah."""
+
     host: str = Field(..., min_length=1)
     port: int = Field(..., ge=1, le=65535)
     output_path: Optional[str] = None
     error_log_path: Optional[str] = None
 
-class Soho:
-    """Interface for collecting data from Ponemah."""
+    _stop: bool = PrivateAttr(False)
+    _active: bool = PrivateAttr(True)
+    _collection_thread: Optional[threading.Thread] = PrivateAttr(None)
+    _listener_thread: Optional[threading.Thread] = PrivateAttr(None)
 
-    def __init__(self, host: str | SohoConfig, port: Optional[int] = None) -> None:
-        if isinstance(host, SohoConfig):
-            self.config = host
-        else:
-            if port is None:
-                raise ValueError("port must be provided when host is a string")
-            self.config = SohoConfig(host=host, port=port)
+    def __init__(self, host: str, port: int, output_path: Optional[str] = None, error_log_path: Optional[str] = None, **kwargs) -> None:
+        super().__init__(host=host, port=port, output_path=output_path, error_log_path=error_log_path, **kwargs)
         self.error_log_file: Optional[str] = None
         self.output_file: Optional[str] = None
-        self._stop = False
         self.data: Optional[pd.DataFrame] = None
         self.experiment_start_time: Optional[float] = None
         self.on_data_callback: Optional[Callable[[], None]] = None
-        self._collection_thread: Optional[threading.Thread] = None
-        self._listener_thread: Optional[threading.Thread] = None
-        self._active = True
 
     def set_error_log_path(self, path: str, file_name: str) -> None:
         """Set the file used for error logging."""
@@ -78,7 +73,7 @@ class Soho:
 
         try:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-                sock.connect((self.config.host, self.config.port))
+                sock.connect((self.host, self.port))
                 sock.settimeout(1.0)
                 while not self._stop:
                     try:
@@ -216,7 +211,7 @@ class Soho:
             "connection. Press Enter when ready to test."
         )
         
-        test_ponemah_connection(self.config.host, self.config.port)
+        test_ponemah_connection(self.host, self.port)
         
         console.input(
             "Close the remote connection test window by pressing 'OK'. "

--- a/poulet_py/hardware/sensor/soho.py
+++ b/poulet_py/hardware/sensor/soho.py
@@ -38,11 +38,20 @@ class Soho(BaseModel):
 
     _stop: bool = PrivateAttr(False)
     _active: bool = PrivateAttr(True)
-    _collection_thread: Optional[threading.Thread] = PrivateAttr(None)
-    _listener_thread: Optional[threading.Thread] = PrivateAttr(None)
+    _collection_thread: threading.Thread | None = PrivateAttr(None)
+    _listener_thread: threading.Thread | None = PrivateAttr(None)
 
-    def __init__(self, host: str, port: int, output_path: str | None = None, error_log_path: str | None = None, **kwargs) -> None:
-        super().__init__(host=host, port=port, output_path=output_path, error_log_path=error_log_path, **kwargs)
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        output_path: str | None = None,
+        error_log_path: str | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            host=host, port=port, output_path=output_path, error_log_path=error_log_path, **kwargs
+        )
         self.error_log_file: str | None = None
         self.output_file: str | None = None
         self.data: pd.DataFrame | None = None

--- a/poulet_py/hardware/sensor/soho.py
+++ b/poulet_py/hardware/sensor/soho.py
@@ -22,7 +22,7 @@ try:
     from socket import socket as Socket
     from struct import unpack
     from subprocess import Popen
-    from threading import Thread
+    from threading import Lock, Thread
     from time import sleep, time
     from typing import Any
 
@@ -142,6 +142,8 @@ class Soho(BaseModel):
     _active: bool = PrivateAttr(True)
     _collection_thread: Thread | None = PrivateAttr(None)
     _keyboard_listener_instance: Listener | None = PrivateAttr(None)
+    _data_lock: Lock = PrivateAttr(default_factory=Lock)
+    _packet_count: int = PrivateAttr(0)
 
     def __init__(
         self,
@@ -231,6 +233,27 @@ class Soho(BaseModel):
         """
         self.on_data_callback = callback
 
+    def _update_data_from_rows(
+        self,
+        rows: dict[tuple[str, str], dict[tuple[str, str], str]],
+        metadata: dict[str, dict[str, Any]],
+        previous_data: DataFrame | None,
+    ) -> None:
+        """Update self.data from current rows for incremental save support."""
+        ordered_rows = list(rows.values())
+        df = DataFrame(ordered_rows)
+        if not df.empty and len(df.columns) > 0:
+            df.columns = MultiIndex.from_tuples(df.columns)
+        if previous_data is not None and not previous_data.empty:
+            if not df.empty:
+                combined = concat([previous_data, df], ignore_index=True)
+            else:
+                combined = previous_data
+        else:
+            combined = df
+        with self._data_lock:
+            self.data = combined
+
     def collect(self) -> DataFrame:
         """
         Collect data from the Ponemah server via TCP socket.
@@ -256,6 +279,7 @@ class Soho(BaseModel):
         metadata: dict[str, dict[str, Any]] = {}
         rows: dict[tuple[str, str], dict[tuple[str, str], str]] = {}
         previous_data = self.data
+        self._packet_count = 0
 
         try:
             with Socket(AF_INET, SOCK_STREAM) as sock:
@@ -315,6 +339,11 @@ class Soho(BaseModel):
                                         Soho.log_error(
                                             f"Error in data callback: {e}", self.error_log_file
                                         )
+                                self._packet_count += 1
+                                if self._packet_count % 100 == 0:
+                                    self._update_data_from_rows(
+                                        rows, metadata, previous_data
+                                    )
                     except TimeoutError:
                         continue
                     except (ConnectionError, OSError) as err:
@@ -330,12 +359,14 @@ class Soho(BaseModel):
 
         if previous_data is not None and not previous_data.empty:
             if not df.empty:
-                self.data = concat([previous_data, df], ignore_index=True)
+                result = concat([previous_data, df], ignore_index=True)
             else:
-                self.data = previous_data
+                result = previous_data
         else:
-            self.data = df
+            result = df
 
+        with self._data_lock:
+            self.data = result
         return self.data
 
     def save(self) -> None:
@@ -351,11 +382,16 @@ class Soho(BaseModel):
         OSError
             If the file cannot be written due to permissions or disk errors.
         """
-        if self.output_file is None or self.data is None:
-            Soho.log_error("Output file or data not set.", self.error_log_file)
+        if self.output_file is None:
+            Soho.log_error("Output file not set.", self.error_log_file)
+            return
+        with self._data_lock:
+            data = self.data
+        if data is None:
+            Soho.log_error("No data to save.", self.error_log_file)
             return
         try:
-            self.data.to_csv(self.output_file, index=False)
+            data.to_csv(self.output_file, index=False)
         except OSError as err:
             Soho.log_error(str(err), self.error_log_file)
 

--- a/poulet_py/hardware/sensor/soho.py
+++ b/poulet_py/hardware/sensor/soho.py
@@ -1,19 +1,19 @@
 try:
-    from typing import Any, Dict, Optional, Tuple, Callable
-
+    import msvcrt
     import os
+    import re
     import socket
     import struct
-    import time
     import threading
-    import pandas as pd
-    import re
-    import msvcrt
+    import time
+    from collections.abc import Callable
+    from typing import Any, Dict, Optional, Tuple
 
+    import pandas as pd
+    from pydantic import BaseModel, Field
     from rich.console import Console
     from rich.prompt import Confirm
 
-    from pydantic import BaseModel, Field
     from poulet_py import LOGGER
 
 except ImportError as e:
@@ -27,30 +27,32 @@ Missing 'soho' module. Install options:
 
 console = Console()
 
+
 class SohoConfig(BaseModel):
     host: str = Field(..., min_length=1)
     port: int = Field(..., ge=1, le=65535)
-    output_path: Optional[str] = None
-    error_log_path: Optional[str] = None
+    output_path: str | None = None
+    error_log_path: str | None = None
+
 
 class Soho:
     """Interface for collecting data from Ponemah."""
 
-    def __init__(self, host: str | SohoConfig, port: Optional[int] = None) -> None:
+    def __init__(self, host: str | SohoConfig, port: int | None = None) -> None:
         if isinstance(host, SohoConfig):
             self.config = host
         else:
             if port is None:
                 raise ValueError("port must be provided when host is a string")
             self.config = SohoConfig(host=host, port=port)
-        self.error_log_file: Optional[str] = None
-        self.output_file: Optional[str] = None
+        self.error_log_file: str | None = None
+        self.output_file: str | None = None
         self._stop = False
-        self.data: Optional[pd.DataFrame] = None
-        self.experiment_start_time: Optional[float] = None
-        self.on_data_callback: Optional[Callable[[], None]] = None
-        self._collection_thread: Optional[threading.Thread] = None
-        self._listener_thread: Optional[threading.Thread] = None
+        self.data: pd.DataFrame | None = None
+        self.experiment_start_time: float | None = None
+        self.on_data_callback: Callable[[], None] | None = None
+        self._collection_thread: threading.Thread | None = None
+        self._listener_thread: threading.Thread | None = None
         self._active = True
 
     def set_error_log_path(self, path: str, file_name: str) -> None:
@@ -72,8 +74,8 @@ class Soho:
 
     def collect(self) -> pd.DataFrame:
         """Collect data from the Ponemah server."""
-        metadata: Dict[str, Dict[str, Any]] = {}
-        rows: Dict[Tuple[str, str], Dict[Tuple[str, str], str]] = {}
+        metadata: dict[str, dict[str, Any]] = {}
+        rows: dict[tuple[str, str], dict[tuple[str, str], str]] = {}
         previous_data = self.data
 
         try:
@@ -104,7 +106,7 @@ class Soho:
                             meta = metadata.get(ref_id)
                             if meta:
                                 param_names = meta["param_names"]
-                                data = dict(zip(param_names, values))
+                                data = dict(zip(param_names, values, strict=False))
 
                                 elapsed = data.pop("ElapsedTime", "")
                                 real = data.pop("RealTime", "")
@@ -126,13 +128,15 @@ class Soho:
                                 channel = meta["channel_label"]
                                 for name, value in data.items():
                                     row[(channel, name)] = value
-                                
+
                                 if self.on_data_callback is not None:
                                     try:
                                         self.on_data_callback()
                                     except Exception as e:
-                                        Soho.log_error(f"Error in data callback: {e}", self.error_log_file)
-                    except socket.timeout:
+                                        Soho.log_error(
+                                            f"Error in data callback: {e}", self.error_log_file
+                                        )
+                    except TimeoutError:
                         continue
                     except (ConnectionError, OSError) as err:
                         Soho.log_error(str(err), self.error_log_file)
@@ -144,17 +148,15 @@ class Soho:
         df = pd.DataFrame(ordered_rows)
         if not df.empty and len(df.columns) > 0:
             df.columns = pd.MultiIndex.from_tuples(df.columns)
-        
+
         if previous_data is not None and not previous_data.empty:
             if not df.empty:
-                self.data = pd.concat(
-                    [previous_data, df], ignore_index=True
-                )
+                self.data = pd.concat([previous_data, df], ignore_index=True)
             else:
                 self.data = previous_data
         else:
             self.data = df
-        
+
         return self.data
 
     def save(self) -> None:
@@ -182,12 +184,10 @@ class Soho:
 
         self._collection_thread = threading.Thread(target=self.collect)
         self._collection_thread.start()
-        
-        self._listener_thread = threading.Thread(
-            target=self._keyboard_listener
-        )
+
+        self._listener_thread = threading.Thread(target=self._keyboard_listener)
         self._listener_thread.start()
-        
+
         console.print("[bold green]Soho recording started.[/bold green]")
 
     def stop(self) -> None:
@@ -206,25 +206,24 @@ class Soho:
         """Pause recording, test connection, and optionally resume."""
         console.print("[bold yellow]Pausing recording...[/bold yellow]")
         self._stop = True
-        
+
         if self._collection_thread:
             self._collection_thread.join()
-        
+
         console.print("[bold cyan]🔌 CONNECTION TEST[/bold cyan]")
         console.input(
             "Go to Ponemah 'Experiment Setup' and click 'Test' remote "
             "connection. Press Enter when ready to test."
         )
-        
+
         test_ponemah_connection(self.config.host, self.config.port)
-        
+
         console.input(
-            "Close the remote connection test window by pressing 'OK'. "
-            "Press Enter when done."
+            "Close the remote connection test window by pressing 'OK'. Press Enter when done."
         )
-        
+
         confirm_resume = Confirm.ask("[yellow]Resume recording? (y/n)[/yellow]", default=True)
-        
+
         if confirm_resume:
             console.input(
                 "[bold yellow]\nWARNING: Ensure that the continuous sampling is "
@@ -242,37 +241,33 @@ class Soho:
         """Monitor keyboard input for stopping or testing connection."""
         if msvcrt is None:
             input()
-            console.print(
-                "Recording finished, stopping Soho, "
-                "waiting for the last reading..."
-            )
+            console.print("Recording finished, stopping Soho, waiting for the last reading...")
             self.stop()
             return
-        
+
         while self._active:
             if msvcrt.kbhit():
                 key = msvcrt.getwch()
-                
+
                 if key.lower() == "e":
                     confirm = Confirm.ask(
-                        "Are you sure you want to stop recording? (y/n): "
-                    , default=True)
-                    
+                        "Are you sure you want to stop recording? (y/n): ", default=True
+                    )
+
                     if confirm:
                         console.print("[bold green]Stopping recording...[/bold green]")
                         self.stop()
                         break
-                
+
                 elif key.lower() == "t":
                     confirm = Confirm.ask(
-                        "Pause recording to test connection? (y/n): "
-                    , default=True)
-                    
+                        "Pause recording to test connection? (y/n): ", default=True
+                    )
+
                     if confirm:
                         self.pause_and_test_connection()
-            
-            time.sleep(0.1)
 
+            time.sleep(0.1)
 
     @staticmethod
     def _read_exact(sock: socket.socket, n: int) -> bytes:
@@ -301,7 +296,6 @@ def test_ponemah_connection(HOST: str, PORT: int) -> None:
                 console.print(f"[red]Unexpected response:[/red] {clean!r}")
         except OSError:
             console.print(
-                "[red]Connection refused, start test in setup remote "
-                "connection test[/red]"
+                "[red]Connection refused, start test in setup remote connection test[/red]"
             )
         time.sleep(1)

--- a/poulet_py/hardware/sensor/soho.py
+++ b/poulet_py/hardware/sensor/soho.py
@@ -265,9 +265,7 @@ class Soho(BaseModel):
             return None
 
         if key_char.lower() == "e":
-            confirm = Confirm.ask(
-                "Are you sure you want to stop recording? (y/n): ", default=True
-            )
+            confirm = Confirm.ask("Are you sure you want to stop recording? (y/n): ", default=True)
 
             if confirm:
                 console.print("[bold green]Stopping recording...[/bold green]")
@@ -275,9 +273,7 @@ class Soho(BaseModel):
                 return False
 
         elif key_char.lower() == "t":
-            confirm = Confirm.ask(
-                "Pause recording to test connection? (y/n): ", default=True
-            )
+            confirm = Confirm.ask("Pause recording to test connection? (y/n): ", default=True)
 
             if confirm:
                 self.pause_and_test_connection()

--- a/poulet_py/hardware/sensor/soho.py
+++ b/poulet_py/hardware/sensor/soho.py
@@ -17,11 +17,11 @@ Examples
 try:
     from collections.abc import Callable
     from os.path import basename, exists, join
-    from subprocess import Popen
     from re import sub
     from socket import AF_INET, SOCK_STREAM, create_connection
     from socket import socket as Socket
     from struct import unpack
+    from subprocess import Popen
     from threading import Thread
     from time import sleep, time
     from typing import Any
@@ -621,6 +621,7 @@ def open_ponemah(
     try:
         if run_as_admin:
             import subprocess
+
             subprocess.run(
                 [
                     "powershell",

--- a/poulet_py/hardware/stimulator/qst.py
+++ b/poulet_py/hardware/stimulator/qst.py
@@ -147,7 +147,7 @@ class TCSStimulus(BaseModel):
     surface : int
         Target surface (0-5, where 0 means all surfaces).
     baseline : float
-        Baseline temperature in °C (16-45).
+        Baseline temperature in °C (20-45).
     target : float
         Target temperature in °C (0-60).
     rise_rate : float
@@ -177,8 +177,8 @@ class TCSStimulus(BaseModel):
     )
     baseline: float = Field(
         30,
-        description="Baseline temperature in °C (16-45)",
-        ge=16,
+        description="Baseline temperature in °C (20-45)",
+        ge=20,
         le=45,
     )
     target: float = Field(

--- a/poulet_py/hardware/stimulator/qst.py
+++ b/poulet_py/hardware/stimulator/qst.py
@@ -147,7 +147,7 @@ class TCSStimulus(BaseModel):
     surface : int
         Target surface (0-5, where 0 means all surfaces).
     baseline : float
-        Baseline temperature in °C (20-45).
+        Baseline temperature in °C (16-45).
     target : float
         Target temperature in °C (0-60).
     rise_rate : float
@@ -177,8 +177,8 @@ class TCSStimulus(BaseModel):
     )
     baseline: float = Field(
         30,
-        description="Baseline temperature in °C (20-45)",
-        ge=20,
+        description="Baseline temperature in °C (16-45)",
+        ge=16,
         le=45,
     )
     target: float = Field(
@@ -311,7 +311,7 @@ class TCS:
         self._write_lock = Lock()
         self._read_lock = Lock()
         self._thread = Thread(target=self._read_loop, daemon=True, name="TCS Serial Reader")
-        self._current_search = None  # (pattern, event, result)
+        self._current_search = None
         self._stimulus = TCSStimulus()
 
     @property
@@ -353,10 +353,10 @@ class TCS:
             " or '/dev/ttyUSB<number>'"
             " or '/dev/tty.usb<something>'\n"
 
-        if not 0 <= self.maximum_temperature <= 60:  # noqa: PLR2004
+        if not 0 <= self.maximum_temperature <= 60:
             msg += "Maximum temperature must be between 0 and 60°C\n"
 
-        if not 1 <= self.trigger_out_channel <= 255:  # noqa: PLR2004
+        if not 1 <= self.trigger_out_channel <= 255:
             msg += "Trigger out channel must be between 1 and 255\n"
 
         if self.read_timeout <= 0:
@@ -433,7 +433,6 @@ class TCS:
             If the write operation fails
         """
         try:
-            # Start reader thread if not already running
             self._start_reader()
             self._serial.flush()
             LOGGER.debug(f"Sending command: {command}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ hardware = ["poulet_py[camera, arduino, julabo, qst, triggers, soho]"]
 tools = ["orjson"]
 utils = ["poulet_py[qst, osc]"]
 # Install all modules
-all = ["poulet_py[converters, hardware, tools, utils]"]
+all = ["poulet_py[converters, hardware, tools, utils, soho]"]
 # Docs
 docs = [
   "sphinx==8.2.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ julabo = ["pyserial==3.5.*"]
 qst = ["pandas==2.3.*", "tqdm==4.67.*", "pyserial==3.5.*"]
 triggers = ["poulet_py[gpio]"]
 gpio = ["gpiozero==2.0.*", "lgpio==0.2.*"]
-soho = ["pandas==2.3.*"]
+soho = ["pandas==2.3.*", "pynput==1.8.*"]
 # Tools
 
 # Utils

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,13 +74,14 @@ julabo = ["pyserial==3.5.*"]
 qst = ["pandas==2.3.*", "tqdm==4.67.*", "pyserial==3.5.*"]
 triggers = ["poulet_py[gpio]"]
 gpio = ["gpiozero==2.0.*", "lgpio==0.2.*"]
+soho = ["pandas==2.3.*"]
 # Tools
 
 # Utils
 osc = ["pandas==2.3.*", "matplotlib==3.10.*", "numpy==2.2.*"]
 ## Main modules ##
 converters = ["poulet_py[seq]"]
-hardware = ["poulet_py[camera, arduino, julabo, qst, triggers]"]
+hardware = ["poulet_py[camera, arduino, julabo, qst, triggers, sensor]"]
 tools = ["orjson"]
 utils = ["poulet_py[qst, osc]"]
 # Install all modules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ soho = ["pandas==2.3.*"]
 osc = ["pandas==2.3.*", "matplotlib==3.10.*", "numpy==2.2.*"]
 ## Main modules ##
 converters = ["poulet_py[seq]"]
-hardware = ["poulet_py[camera, arduino, julabo, qst, triggers, sensor]"]
+hardware = ["poulet_py[camera, arduino, julabo, qst, triggers, soho]"]
 tools = ["orjson"]
 utils = ["poulet_py[qst, osc]"]
 # Install all modules


### PR DESCRIPTION
This PR introduces Soho, a small client to collect telemetry data from PONEMAH (the software driving our implant telemetry probes for mouse core temperature). I’ve been using this code across projects with Amanda and Gamze; this brings it into poulet_py so we can reuse it consistently. I've done a bit of pydantic.