### PR TITLE
fix: source teardown and thermal camera lifecycle

### DIFF
--- a/examples/drv2605_tcs_nidaq.py
+++ b/examples/drv2605_tcs_nidaq.py
@@ -112,7 +112,6 @@ sources = [
         buffer_size=16,
         vminT=30,
         vmaxT=40,
-        frame_rate_fps=8.7,
         emissivity=0.95,
     ),
     INA228Source(

--- a/poulet_py/hardware/camera/thermal_camera.py
+++ b/poulet_py/hardware/camera/thermal_camera.py
@@ -22,8 +22,6 @@ try:
     import signal
     import sys
 
-    from scipy import ndimage
-
     from poulet_py import LOGGER, setup_logging
 
     def py_frame_callback(frame, userptr):
@@ -105,36 +103,33 @@ class ThermalCamera:
     A class to interact with the Lepton 3.5 thermal camera.
     """
 
-    def __init__(self, vminT=30, vmaxT=40, frame_rate_fps=8.7, emissivity=0.95):
+    def __init__(self, vminT=30, vmaxT=40, emissivity=0.95):
         """
         Initializes the ThermalCamera object.
 
         Args:
             vminT (int, optional): Minimum temperature threshold. Defaults to 30.
             vmaxT (int, optional): Maximum temperature threshold. Defaults to 40.
-            frame_rate_fps (float, optional): Requested UVC acquisition frame rate.
-                The Lepton/PureThermal combination normally exposes a nominal 9 Hz
-                stream. Defaults to 8.7.
             emissivity (float, optional): Scene emissivity used by the Lepton's
                 native T-Linear radiometry calculation. Must be in [0.01, 1.0].
                 Defaults to 0.95.
         """
-        frame_rate_fps = float(frame_rate_fps)
         emissivity = float(emissivity)
-        if not 0 < frame_rate_fps <= 9:
-            raise ValueError("frame_rate_fps must be greater than 0 and at most 9")
         if not 0.01 <= emissivity <= 1.0:
             raise ValueError("emissivity must be between 0.01 and 1.0")
 
         self.vminT = int(vminT)
         self.vmaxT = int(vmaxT)
-        self.requested_frames_per_second = frame_rate_fps
-        self.frames_per_second = frame_rate_fps
+        self.frames_per_second = None
         self.emissivity = emissivity
         self.width = 160
         self.height = 120
         self.video_format = None
         self._flux_linear_params = None
+        self._ctx = None
+        self._dev = None
+        self._devh = None
+        self._streaming = False
 
         self.shutter_manual = False
 
@@ -145,117 +140,110 @@ class ThermalCamera:
 
         LOGGER.info("Object thermal camera initialized")
         LOGGER.info(
-            "vminT = %s, vmaxT = %s, requested frame rate = %.3f fps, emissivity = %.4f",
+            "vminT = %s, vmaxT = %s, emissivity = %.4f (native frame rate)",
             self.vminT,
             self.vmaxT,
-            self.requested_frames_per_second,
             self.emissivity,
         )
 
     def start_streaming(self):
-        global devh
-        global dev
         """
         Method to start streaming. This method needs to be called always
         before you can extract the data from the camera.
         """
+        if self._streaming:
+            return
+
         if self.windows:
             self.windows_camera.initialise_camera()
             self.set_emissivity(self.emissivity)
-            if abs(self.requested_frames_per_second - 8.7) > 0.01:
-                LOGGER.warning(
-                    "The Windows IR16Capture backend does not expose frame-rate "
-                    "negotiation; using the camera's nominal 8.7 fps stream"
-                )
             self.frames_per_second = 8.7
             time.sleep(1)
             self.windows_camera.start_streaming()
-        else:
-            ctx = POINTER(uvc_context)()
-            dev = POINTER(uvc_device)()
-            devh = POINTER(uvc_device_handle)()
-            ctrl = uvc_stream_ctrl()
-            LOGGER.debug(ctrl.__dict__)
+            self._streaming = True
+            return
 
-            res = libuvc.uvc_init(byref(ctx), 0)
+        ctx = POINTER(uvc_context)()
+        dev = POINTER(uvc_device)()
+        devh = POINTER(uvc_device_handle)()
+        ctrl = uvc_stream_ctrl()
+
+        res = libuvc.uvc_init(byref(ctx), 0)
+        if res < 0:
+            raise RuntimeError(f"uvc_init error: {res}")
+        self._ctx = ctx
+
+        try:
+            res = libuvc.uvc_find_device(
+                ctx, byref(dev), PT_USB_VID, PT_USB_PID, 0
+            )
             if res < 0:
-                LOGGER.error("uvc_init error")
-                exit(1)
+                raise RuntimeError(f"uvc_find_device error: {res}")
+            self._dev = dev
 
-            try:
-                res = libuvc.uvc_find_device(ctx, byref(dev), PT_USB_VID, PT_USB_PID, 0)
-                LOGGER.debug(res)
-                if res < 0:
-                    LOGGER.error("uvc_find_device error")
-                    exit(1)
+            res = libuvc.uvc_open(dev, byref(devh))
+            if res < 0:
+                raise RuntimeError(f"uvc_open error: {res}")
+            self._devh = devh
+            LOGGER.info("device opened!")
 
-                try:
-                    res = libuvc.uvc_open(dev, byref(devh))
-                    LOGGER.debug(res)
-                    if res < 0:
-                        LOGGER.error("uvc_open error")
-                        exit(1)
+            frame_formats = uvc_get_frame_formats_by_guid(
+                devh, VS_FMT_GUID_Y16
+            )
+            if len(frame_formats) == 0:
+                raise RuntimeError("device does not support Y16")
 
-                    LOGGER.info("device opened!")
+            default_interval = int(frame_formats[0].dwDefaultFrameInterval)
+            native_fps = (
+                max(1, int(round(1e7 / default_interval)))
+                if default_interval > 0
+                else 9
+            )
+            res = libuvc.uvc_get_stream_ctrl_format_size(
+                devh,
+                byref(ctrl),
+                UVC_FRAME_FORMAT_Y16,
+                frame_formats[0].wWidth,
+                frame_formats[0].wHeight,
+                native_fps,
+            )
+            if res < 0:
+                raise RuntimeError(
+                    "uvc_get_stream_ctrl_format_size failed for native "
+                    f"{native_fps} fps: {res}"
+                )
 
-                    frame_formats = uvc_get_frame_formats_by_guid(devh, VS_FMT_GUID_Y16)
-                    if len(frame_formats) == 0:
-                        LOGGER.error("device does not support Y16")
-                        exit(1)
+            if ctrl.dwFrameInterval:
+                self.frames_per_second = 1e7 / ctrl.dwFrameInterval
+            else:
+                self.frames_per_second = float(native_fps)
 
-                    requested_uvc_fps = max(1, int(self.requested_frames_per_second + 0.5))
-                    res = libuvc.uvc_get_stream_ctrl_format_size(
-                        devh,
-                        byref(ctrl),
-                        UVC_FRAME_FORMAT_Y16,
-                        frame_formats[0].wWidth,
-                        frame_formats[0].wHeight,
-                        requested_uvc_fps,
-                    )
-                    if res < 0:
-                        raise RuntimeError(
-                            "The camera rejected the requested frame rate "
-                            f"{self.requested_frames_per_second:.3f} fps "
-                            f"(UVC request {requested_uvc_fps} fps): {res}"
-                        )
+            LOGGER.info(
+                "UVC native frame rate negotiated %.3f fps",
+                self.frames_per_second,
+            )
 
-                    if ctrl.dwFrameInterval:
-                        self.frames_per_second = 1e7 / ctrl.dwFrameInterval
-                    else:
-                        self.frames_per_second = float(requested_uvc_fps)
+            # Configure radiometry before the first frame is produced.
+            self.set_emissivity(self.emissivity)
 
-                    LOGGER.info(
-                        "UVC frame rate requested %.3f fps; negotiated %.3f fps",
-                        self.requested_frames_per_second,
-                        self.frames_per_second,
-                    )
+            res = libuvc.uvc_start_streaming(
+                devh, byref(ctrl), PTR_PY_FRAME_CALLBACK, None, 0
+            )
+            if res < 0:
+                raise RuntimeError(f"uvc_start_streaming failed: {res}")
+            self._streaming = True
 
-                    # Configure radiometry before the first frame is produced.
-                    self.set_emissivity(self.emissivity)
-
-                    res = libuvc.uvc_start_streaming(
-                        devh, byref(ctrl), PTR_PY_FRAME_CALLBACK, None, 0
-                    )
-                    if res < 0:
-                        LOGGER.error(f"uvc_start_streaming failed: {res}")
-                        exit(1)
-
-                    LOGGER.info("done starting stream, displaying settings")
-                    print_shutter_info(devh)
-                    LOGGER.info("resetting settings to default")
-                    set_auto_ffc(devh)
-                    set_gain_high(devh)
-                    LOGGER.info("current settings")
-                    print_shutter_info(devh)
-
-                except:
-                    libuvc.uvc_unref_device(dev)
-                    LOGGER.error("Failed to Open Device")
-                    exit(1)
-            except:
-                libuvc.uvc_exit(ctx)
-                LOGGER.error("Failed to Find Device")
-                exit(1)
+            LOGGER.info("done starting stream, displaying settings")
+            print_shutter_info(devh)
+            LOGGER.info("resetting settings to default")
+            set_auto_ffc(devh)
+            set_gain_high(devh)
+            LOGGER.info("current settings")
+            print_shutter_info(devh)
+        except Exception:
+            LOGGER.exception("Failed to start thermal camera stream")
+            self.stop_streaming()
+            raise
 
     def set_emissivity(self, emissivity):
         """Set scene emissivity used by the camera's T-Linear calculation.
@@ -270,37 +258,41 @@ class ThermalCamera:
         if self.windows:
             self.windows_camera.set_emissivity(emissivity)
         else:
-            global devh
-
-            if not devh:
-                raise RuntimeError("Thermal camera must be opened before setting emissivity")
+            if not self._devh:
+                raise RuntimeError(
+                    "Thermal camera must be opened before setting emissivity"
+                )
 
             if self._flux_linear_params is None:
                 self._flux_linear_params = lep_rad_flux_linear_params()
                 get_command = 0xBC
                 control_id = (get_command >> 2) + 1
                 res = call_extension_unit(
-                    devh,
+                    self._devh,
                     RAD_UNIT_ID,
                     control_id,
                     byref(self._flux_linear_params),
                     sizeof(self._flux_linear_params),
                 )
                 if res < 0:
-                    raise RuntimeError(f"Failed to read radiometry parameters: {res}")
+                    raise RuntimeError(
+                        f"Failed to read radiometry parameters: {res}"
+                    )
 
             self._flux_linear_params.sceneEmissivity = round(emissivity * 8192)
             set_command = 0xBD
             control_id = (set_command >> 2) + 1
             res = set_extension_unit(
-                devh,
+                self._devh,
                 RAD_UNIT_ID,
                 control_id,
                 byref(self._flux_linear_params),
                 sizeof(self._flux_linear_params),
             )
             if res < 0:
-                raise RuntimeError(f"Failed to set emissivity to {emissivity}: {res}")
+                raise RuntimeError(
+                    f"Failed to set emissivity to {emissivity}: {res}"
+                )
 
         self.emissivity = emissivity
 
@@ -351,16 +343,14 @@ class ThermalCamera:
         """
         Sets the camera shutter to manual mode.
         """
-        global devh
-
         LOGGER.info("Shutter is now manual.")
         try:
             if self.windows:
                 self.windows_camera.set_shutter_manual()
-            else:
-                set_manual_ffc(devh)
-        except:
-            LOGGER.error("Failed to set shutter to manual.")
+            elif self._devh:
+                set_manual_ffc(self._devh)
+        except Exception:
+            LOGGER.exception("Failed to set shutter to manual.")
         finally:
             self.shutter_manual = True
 
@@ -368,29 +358,63 @@ class ThermalCamera:
         """
         Performs a manual Flat Field Correction (FFC).
         """
-        global devh
-
         LOGGER.info("Manual FFC")
         if self.windows:
             self.windows_camera.perform_manual_ffc()
-        else:
-            perform_manual_ffc(devh)
-            print_shutter_info(devh)
+        elif self._devh:
+            perform_manual_ffc(self._devh)
+            print_shutter_info(self._devh)
 
     def stop_streaming(self):
         """
-        Stops the camera stream.
+        Stops the camera stream and fully releases the UVC device.
         """
-        global devh
-
-        if self.video_format == "hdf5" and self.create_hdf5_file:
-            self.hpy_file.close()
+        if (
+            self.video_format == "hdf5"
+            and getattr(self, "hpy_file", None) is not None
+        ):
+            try:
+                self.hpy_file.close()
+            except Exception:
+                LOGGER.exception("Failed to close thermal HDF5 file")
 
         LOGGER.info("Stop streaming")
         if self.windows:
-            self.windows_camera.stop_streaming()
-        else:
-            libuvc.uvc_stop_streaming(devh)
+            if self._streaming:
+                try:
+                    self.windows_camera.stop_streaming()
+                except Exception:
+                    LOGGER.exception("Failed to stop Windows thermal stream")
+            self._streaming = False
+            return
+
+        if self._streaming and self._devh:
+            try:
+                libuvc.uvc_stop_streaming(self._devh)
+            except Exception:
+                LOGGER.exception("uvc_stop_streaming failed")
+        self._streaming = False
+
+        if self._devh:
+            try:
+                libuvc.uvc_close(self._devh)
+            except Exception:
+                LOGGER.exception("uvc_close failed")
+            self._devh = None
+
+        if self._dev:
+            try:
+                libuvc.uvc_unref_device(self._dev)
+            except Exception:
+                LOGGER.exception("uvc_unref_device failed")
+            self._dev = None
+
+        if self._ctx:
+            try:
+                libuvc.uvc_exit(self._ctx)
+            except Exception:
+                LOGGER.exception("uvc_exit failed")
+            self._ctx = None
 
     def create_hdf5_file(self):
         """
@@ -644,7 +668,6 @@ class ThermalCamera:
             "resolution_width": self.width,
             "resolution_height": self.height,
             "frame_rate_fps": self.frames_per_second,
-            "requested_frame_rate_fps": self.requested_frames_per_second,
             "emissivity": self.emissivity,
             "output_file": self.output_file_name,
             "temperature_min": self.vminT,
@@ -680,9 +703,8 @@ class CameraWindows:
         """
         Add a new frame to the buffer of read data.
         """
-        img = np.fromiter(array, dtype="uint16").reshape(height, width)  # parse
-        img = ndimage.rotate(img, angle=0, reshape=True)  # rotation
-        self.latest_frame = img.astype(np.float16)  # update the last reading
+        img = np.fromiter(array, dtype="uint16").reshape(height, width)
+        self.latest_frame = img.astype(np.float16)
 
     def initialise_camera(self):
         """

--- a/poulet_py/hardware/camera/thermal_camera.py
+++ b/poulet_py/hardware/camera/thermal_camera.py
@@ -174,9 +174,7 @@ class ThermalCamera:
         self._ctx = ctx
 
         try:
-            res = libuvc.uvc_find_device(
-                ctx, byref(dev), PT_USB_VID, PT_USB_PID, 0
-            )
+            res = libuvc.uvc_find_device(ctx, byref(dev), PT_USB_VID, PT_USB_PID, 0)
             if res < 0:
                 raise RuntimeError(f"uvc_find_device error: {res}")
             self._dev = dev
@@ -187,18 +185,12 @@ class ThermalCamera:
             self._devh = devh
             LOGGER.info("device opened!")
 
-            frame_formats = uvc_get_frame_formats_by_guid(
-                devh, VS_FMT_GUID_Y16
-            )
+            frame_formats = uvc_get_frame_formats_by_guid(devh, VS_FMT_GUID_Y16)
             if len(frame_formats) == 0:
                 raise RuntimeError("device does not support Y16")
 
             default_interval = int(frame_formats[0].dwDefaultFrameInterval)
-            native_fps = (
-                max(1, int(round(1e7 / default_interval)))
-                if default_interval > 0
-                else 9
-            )
+            native_fps = max(1, int(round(1e7 / default_interval))) if default_interval > 0 else 9
             res = libuvc.uvc_get_stream_ctrl_format_size(
                 devh,
                 byref(ctrl),
@@ -209,8 +201,7 @@ class ThermalCamera:
             )
             if res < 0:
                 raise RuntimeError(
-                    "uvc_get_stream_ctrl_format_size failed for native "
-                    f"{native_fps} fps: {res}"
+                    f"uvc_get_stream_ctrl_format_size failed for native {native_fps} fps: {res}"
                 )
 
             if ctrl.dwFrameInterval:
@@ -226,9 +217,7 @@ class ThermalCamera:
             # Configure radiometry before the first frame is produced.
             self.set_emissivity(self.emissivity)
 
-            res = libuvc.uvc_start_streaming(
-                devh, byref(ctrl), PTR_PY_FRAME_CALLBACK, None, 0
-            )
+            res = libuvc.uvc_start_streaming(devh, byref(ctrl), PTR_PY_FRAME_CALLBACK, None, 0)
             if res < 0:
                 raise RuntimeError(f"uvc_start_streaming failed: {res}")
             self._streaming = True
@@ -259,9 +248,7 @@ class ThermalCamera:
             self.windows_camera.set_emissivity(emissivity)
         else:
             if not self._devh:
-                raise RuntimeError(
-                    "Thermal camera must be opened before setting emissivity"
-                )
+                raise RuntimeError("Thermal camera must be opened before setting emissivity")
 
             if self._flux_linear_params is None:
                 self._flux_linear_params = lep_rad_flux_linear_params()
@@ -275,9 +262,7 @@ class ThermalCamera:
                     sizeof(self._flux_linear_params),
                 )
                 if res < 0:
-                    raise RuntimeError(
-                        f"Failed to read radiometry parameters: {res}"
-                    )
+                    raise RuntimeError(f"Failed to read radiometry parameters: {res}")
 
             self._flux_linear_params.sceneEmissivity = round(emissivity * 8192)
             set_command = 0xBD
@@ -290,9 +275,7 @@ class ThermalCamera:
                 sizeof(self._flux_linear_params),
             )
             if res < 0:
-                raise RuntimeError(
-                    f"Failed to set emissivity to {emissivity}: {res}"
-                )
+                raise RuntimeError(f"Failed to set emissivity to {emissivity}: {res}")
 
         self.emissivity = emissivity
 
@@ -369,10 +352,7 @@ class ThermalCamera:
         """
         Stops the camera stream and fully releases the UVC device.
         """
-        if (
-            self.video_format == "hdf5"
-            and getattr(self, "hpy_file", None) is not None
-        ):
+        if self.video_format == "hdf5" and getattr(self, "hpy_file", None) is not None:
             try:
                 self.hpy_file.close()
             except Exception:

--- a/poulet_py/hardware/daq/nidaq.py
+++ b/poulet_py/hardware/daq/nidaq.py
@@ -200,6 +200,8 @@ class NIBaseTask(BaseModel, ABC):
         if self._is_open:
             return
 
+        if self._task is None:
+            self._task = Task()
         self._open()
         self._is_open = True
 
@@ -213,8 +215,11 @@ class NIBaseTask(BaseModel, ABC):
         if not self._is_open:
             return
 
-        self._task.close()
-        self._task = Task()
+        if self._task is not None:
+            try:
+                self._task.close()
+            finally:
+                self._task = None
         self._is_open = False
 
     def start(self) -> None:
@@ -698,7 +703,10 @@ class NIDaQ(BaseModel):
             return
 
         for task in self.tasks:
-            task.close()
+            try:
+                task.close()
+            except Exception:
+                pass
 
         if self._executor is not None:
             self._executor.shutdown(wait=True)

--- a/poulet_py/io/sources/tcam.py
+++ b/poulet_py/io/sources/tcam.py
@@ -29,12 +29,6 @@ class TCAMSource(BaseSource):
 
     vminT: int = Field(default=30, description="Lower preview temperature in Celsius")
     vmaxT: int = Field(default=34, description="Upper preview temperature in Celsius")
-    frame_rate_fps: float = Field(
-        default=8.0,
-        gt=0,
-        le=8.7,
-        description="Requested UVC acquisition frame rate (max 8.7)",
-    )
     emissivity: float = Field(
         default=0.95,
         ge=0.01,
@@ -66,17 +60,24 @@ class TCAMSource(BaseSource):
         self._acquisition_thread.start()
 
     def close(self) -> None:
-        if not self._is_open:
-            return
-
-        # Stop all writes before BaseSource removes its circular buffer.
+        # Always stop the drain thread and release UVC, even if open() failed
+        # before BaseSource marked the source as open.
         self._stop_acquisition.set()
         if self._acquisition_thread is not None:
             self._acquisition_thread.join(timeout=self.frame_timeout_s + 1.0)
             if self._acquisition_thread.is_alive():
                 LOGGER.warning("%s frame-drain thread did not stop", self.name)
         self._acquisition_thread = None
-        super().close()
+
+        if self._camera is not None:
+            try:
+                self._camera.stop_streaming()
+            except Exception:
+                LOGGER.exception("%s failed to stop thermal camera", self.name)
+            self._camera = None
+
+        if self._is_open:
+            super().close()
 
     def _set_buffer_dtype(self) -> None:
         if self._camera is None:
@@ -104,7 +105,6 @@ class TCAMSource(BaseSource):
         self._camera = ThermalCamera(
             vminT=self.vminT,
             vmaxT=self.vmaxT,
-            frame_rate_fps=self.frame_rate_fps,
             emissivity=self.emissivity,
         )
         self._camera.start_streaming()

--- a/poulet_py/utils/stimulator.py
+++ b/poulet_py/utils/stimulator.py
@@ -202,20 +202,44 @@ class StimulatorRuntime(BaseModel):
         if self._is_open:
             return
 
-        if not self._external_bus:
-            self.bus.open()
+        opened_sources: list = []
+        opened_sinks: list = []
+        bus_opened = False
 
-        for source in self.sources:
-            source.bus = self.bus
-            source.open()
+        try:
+            if not self._external_bus:
+                self.bus.open()
+                bus_opened = True
 
-        for sink in self.sinks:
-            sink.bus = self.bus
-            sink.open()
+            for source in self.sources:
+                source.bus = self.bus
+                source.open()
+                opened_sources.append(source)
 
-        self._key_bindings = self._create_key_bindings()
+            for sink in self.sinks:
+                sink.bus = self.bus
+                sink.open()
+                opened_sinks.append(sink)
 
-        self._is_open = True
+            self._key_bindings = self._create_key_bindings()
+            self._is_open = True
+        except Exception:
+            for sink in reversed(opened_sinks):
+                try:
+                    sink.close()
+                except Exception:
+                    pass
+            for source in reversed(opened_sources):
+                try:
+                    source.close()
+                except Exception:
+                    pass
+            if bus_opened and not self._external_bus:
+                try:
+                    self.bus.close()
+                except Exception:
+                    pass
+            raise
 
     def close(self):
         """
@@ -237,13 +261,22 @@ class StimulatorRuntime(BaseModel):
         self._stopped.clear()
 
         for sink in self.sinks:
-            sink.close()
+            try:
+                sink.close()
+            except Exception:
+                pass
 
         for source in self.sources:
-            source.close()
+            try:
+                source.close()
+            except Exception:
+                pass
 
         if not self._external_bus:
-            self.bus.close()
+            try:
+                self.bus.close()
+            except Exception:
+                pass
 
     def run(self):
         """

--- a/tests/hardware/camera/test_thermal_camera_lifecycle.py
+++ b/tests/hardware/camera/test_thermal_camera_lifecycle.py
@@ -1,0 +1,116 @@
+"""Lifecycle tests for ThermalCamera without real UVC hardware."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _FakePointer:
+    def __init__(self, value=None):
+        self.value = value
+
+
+def test_start_streaming_raises_instead_of_exiting(monkeypatch):
+    import poulet_py.hardware.camera.thermal_camera as module
+
+    monkeypatch.setattr(module.platform, "system", lambda: "Linux")
+
+    calls = []
+
+    class FakeLib:
+        def uvc_init(self, *_args):
+            return -1
+
+        def uvc_exit(self, *_args):
+            calls.append("exit")
+
+        def uvc_stop_streaming(self, *_args):
+            calls.append("stop")
+
+        def uvc_close(self, *_args):
+            calls.append("close")
+
+        def uvc_unref_device(self, *_args):
+            calls.append("unref")
+
+    monkeypatch.setattr(module, "libuvc", FakeLib())
+    monkeypatch.setattr(
+        module,
+        "POINTER",
+        lambda *_args, **_kwargs: (lambda: _FakePointer()),
+    )
+    monkeypatch.setattr(module, "byref", lambda value: value)
+    monkeypatch.setattr(module, "uvc_context", object)
+    monkeypatch.setattr(module, "uvc_device", object)
+    monkeypatch.setattr(module, "uvc_device_handle", object)
+    monkeypatch.setattr(module, "uvc_stream_ctrl", lambda: SimpleNamespace())
+
+    camera = module.ThermalCamera(vminT=18, vmaxT=42, emissivity=0.95)
+    with pytest.raises(RuntimeError, match="uvc_init"):
+        camera.start_streaming()
+    assert camera._streaming is False
+
+
+def test_stop_streaming_releases_handles_in_order(monkeypatch):
+    import poulet_py.hardware.camera.thermal_camera as module
+
+    monkeypatch.setattr(module.platform, "system", lambda: "Linux")
+    order = []
+
+    class FakeLib:
+        def uvc_stop_streaming(self, handle):
+            order.append(("stop", handle))
+
+        def uvc_close(self, handle):
+            order.append(("close", handle))
+
+        def uvc_unref_device(self, handle):
+            order.append(("unref", handle))
+
+        def uvc_exit(self, handle):
+            order.append(("exit", handle))
+
+    monkeypatch.setattr(module, "libuvc", FakeLib())
+    camera = module.ThermalCamera(vminT=18, vmaxT=42)
+    camera.windows = False
+    camera._streaming = True
+    camera._devh = "devh"
+    camera._dev = "dev"
+    camera._ctx = "ctx"
+
+    camera.stop_streaming()
+
+    assert order == [
+        ("stop", "devh"),
+        ("close", "devh"),
+        ("unref", "dev"),
+        ("exit", "ctx"),
+    ]
+    assert camera._streaming is False
+    assert camera._devh is None
+    assert camera._dev is None
+    assert camera._ctx is None
+
+
+def test_constructor_rejects_frame_rate_kwarg():
+    from poulet_py.hardware.camera.thermal_camera import ThermalCamera
+
+    with pytest.raises(TypeError):
+        ThermalCamera(frame_rate_fps=8.0)
+
+
+def test_tcam_close_releases_camera_when_not_marked_open():
+    from poulet_py.io.sources.tcam import TCAMSource
+
+    source = TCAMSource(name="tcam", vminT=18, vmaxT=42)
+    camera = MagicMock()
+    source._camera = camera
+    source._is_open = False
+
+    source.close()
+
+    camera.stop_streaming.assert_called_once()
+    assert source._camera is None

--- a/tests/hardware/camera/test_thermal_camera_lifecycle.py
+++ b/tests/hardware/camera/test_thermal_camera_lifecycle.py
@@ -40,7 +40,7 @@ def test_start_streaming_raises_instead_of_exiting(monkeypatch):
     monkeypatch.setattr(
         module,
         "POINTER",
-        lambda *_args, **_kwargs: (lambda: _FakePointer()),
+        lambda *_args, **_kwargs: lambda: _FakePointer(),
     )
     monkeypatch.setattr(module, "byref", lambda value: value)
     monkeypatch.setattr(module, "uvc_context", object)

--- a/tests/hardware/daq/test_nidaq_task_close.py
+++ b/tests/hardware/daq/test_nidaq_task_close.py
@@ -1,0 +1,38 @@
+"""NIBaseTask close must not leave a replacement Task for GC warnings."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def test_nibaseline_close_sets_task_to_none(monkeypatch):
+    from poulet_py.hardware.daq import nidaq as module
+
+    fake_task = MagicMock()
+    monkeypatch.setattr(module, "Task", MagicMock(return_value=fake_task))
+
+    class DummyTask(module.NIBaseTask):
+        _requires_clock = False
+
+        def _open(self) -> None:
+            return None
+
+    task = DummyTask.model_construct(
+        name="ai",
+        device="Dev1",
+        clock=None,
+    )
+    task._requires_clock = False
+    task._task = fake_task
+    task._is_open = True
+
+    task.close()
+
+    fake_task.close.assert_called_once()
+    assert task._task is None
+    assert task._is_open is False
+
+    # Re-open allocates a fresh Task instead of reusing a leaked empty one.
+    task.open()
+    assert task._task is fake_task
+    assert task._is_open is True

--- a/tests/utils/test_stimulator_open_unwind.py
+++ b/tests/utils/test_stimulator_open_unwind.py
@@ -1,0 +1,62 @@
+"""StimulatorRuntime open-failure cleanup."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+class FakeIO:
+    def __init__(self, name: str, fail: bool = False):
+        self.name = name
+        self.fail = fail
+        self.opened = False
+        self.closed = False
+        self.bus = None
+
+    def open(self):
+        if self.fail:
+            raise RuntimeError(f"{self.name} open failed")
+        self.opened = True
+
+    def close(self):
+        self.closed = True
+
+
+def test_open_failure_closes_already_opened_sources(monkeypatch):
+    from poulet_py.utils.stimulator import StimulatorRuntime
+
+    sources = [
+        FakeIO("s0"),
+        FakeIO("s1"),
+        FakeIO("s2", fail=True),
+        FakeIO("s3"),
+    ]
+    sinks = [FakeIO("sink0")]
+
+    runtime = StimulatorRuntime.model_construct(
+        name="test",
+        sources=sources,
+        sinks=sinks,
+        blocks=[],
+        isi=0,
+    )
+    runtime._external_bus = True
+    runtime._is_open = False
+    runtime.bus = SimpleNamespace(open=lambda: None, close=lambda: None)
+    runtime._create_key_bindings = lambda: {}
+    runtime._started = SimpleNamespace(clear=lambda: None)
+    runtime._paused = SimpleNamespace(clear=lambda: None)
+    runtime._aborted = SimpleNamespace(clear=lambda: None)
+    runtime._stopped = SimpleNamespace(clear=lambda: None)
+
+    with pytest.raises(RuntimeError, match="s2 open failed"):
+        runtime.open()
+
+    assert sources[0].opened and sources[0].closed
+    assert sources[1].opened and sources[1].closed
+    assert not sources[2].opened
+    assert not sources[3].opened
+    assert not sinks[0].opened
+    assert runtime._is_open is False


### PR DESCRIPTION
## Summary
- Fully release PureThermal/Lepton UVC handles on stop (close/unref/exit), raise instead of `exit(1)`, and use native frame rate only.
- Make `TCAMSource.close` always release the camera; drop `frame_rate_fps`.
- Unwind already-opened sources/sinks if `StimulatorRuntime.open` fails mid-list.
- Set `NIBaseTask._task = None` on close so experiment→test no longer hits spare-Task GC warnings.
- Add unit tests for lifecycle, stimulator unwind, and NI-DAQ close (no hardware required).

## Test plan
- [x] `pytest tests/hardware/camera/test_thermal_camera_lifecycle.py tests/utils/test_stimulator_open_unwind.py tests/hardware/daq/test_nidaq_task_close.py -q`
- [ ] On rig: open thermal preview (menu 8), close, open again — no `uvc_open` / segfault
- [ ] On rig: run experiment then test recording — no NI-DAQ `DaqResourceWarning`


Made with [Cursor](https://cursor.com)